### PR TITLE
extend rule about adding $ sign in variable names

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1274,7 +1274,7 @@ getData(function getDataCallback ( data ) {
 });
 ```
 
-Use leading `$` to indicate that a DOM element is assigned to variable or property.
+Use leading `$` to indicate that a DOM node is assigned to variable or property.
 
 ```js
 // bad
@@ -1288,7 +1288,8 @@ this.$shadow = {
 
 ```js
 // good
-var $body = document.querySelector('div.page');
+var $body = document.querySelector('div.page'),
+    $text = document.createTextNode('something awesome');
 
 this.shadows = {
     $left: document.createElement('div'),


### PR DESCRIPTION
There are many different types of nodes besides "usual" DOM elements (divs, spans, etc.),
text nodes for example, which are all DOM stuff, but more precisely speaking are "nodes" rather than "elements".